### PR TITLE
Force perms on shell scripts

### DIFF
--- a/ratchet-cycle.sh
+++ b/ratchet-cycle.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Apparently there is disagreement about the file
+# perms depending on the build context; they ought to be +x
+chmod +x *.sh
+
 if [ ! -e "/key.pem" ]; then
     openssl genrsa -passout pass:$RATCHET_PAWL_MASKING_KEY -aes256 -out key.pem 4096
     openssl req -x509 \


### PR DESCRIPTION
Git definitely can do something with file perms, but it pretty much fits on one page so, I'm not too concerned about this becoming unmaintainable.